### PR TITLE
Fix the test_accuracy function by modifying the assertion logic

### DIFF
--- a/econml/tests/test_discrete_outcome.py
+++ b/econml/tests/test_discrete_outcome.py
@@ -52,6 +52,7 @@ class TestDiscreteOutcome(unittest.TestCase):
                 else:
                     est.fit(Y, D, W=W)
                     ate_lb, ate_ub = est.ate_interval()
+
                 if isinstance(est, LinearDRLearner):
                     est.summary(T=1)
                 else:
@@ -237,6 +238,6 @@ class TestDiscreteOutcome(unittest.TestCase):
                 if isinstance(est, LinearDRLearner):
                     est.model_regression = LinearRegression()
                 else:
-                    est.model_y = LinearRegression() 
+                    est.model_y = LinearRegression()
                 with pytest.warns(UserWarning):
                     est.fit(Y=Y, T=T, X=X)

--- a/econml/tests/test_discrete_outcome.py
+++ b/econml/tests/test_discrete_outcome.py
@@ -28,21 +28,22 @@ class TestDiscreteOutcome(unittest.TestCase):
         discrete_treatment = True
         true_ate = 0.3
         num_iterations = 10
-        count_within_interval = 0
 
-        for _ in range(num_iterations):
+        ests = [
+            LinearDML(discrete_outcome=discrete_outcome, discrete_treatment=discrete_treatment),
+            CausalForestDML(discrete_outcome=discrete_outcome, discrete_treatment=discrete_treatment),
+            LinearDRLearner(discrete_outcome=discrete_outcome)
+        ]
 
-            W = np.random.uniform(-1, 1, size=(n, 1))
-            D = np.random.binomial(1, .5 + .1 * W[:, 0], size=(n,))
-            Y = np.random.binomial(1, .5 + true_ate * D + .1 * W[:, 0], size=(n,))
+        for est in ests:
 
-            ests = [
-                LinearDML(discrete_outcome=discrete_outcome, discrete_treatment=discrete_treatment),
-                CausalForestDML(discrete_outcome=discrete_outcome, discrete_treatment=discrete_treatment),
-                LinearDRLearner(discrete_outcome=discrete_outcome)
-            ]
+            count_within_interval = 0
 
-            for est in ests:
+            for _ in range(num_iterations):
+
+                W = np.random.uniform(-1, 1, size=(n, 1))
+                D = np.random.binomial(1, .5 + .1 * W[:, 0], size=(n,))
+                Y = np.random.binomial(1, .5 + true_ate * D + .1 * W[:, 0], size=(n,))
 
                 if isinstance(est, CausalForestDML):
                     est.fit(Y, D, X=W)
@@ -51,22 +52,26 @@ class TestDiscreteOutcome(unittest.TestCase):
                 else:
                     est.fit(Y, D, W=W)
                     ate_lb, ate_ub = est.ate_interval()
+                if isinstance(est, LinearDRLearner):
+                    est.summary(T=1)
+                else:
+                    est.summary()
 
                 if ate_lb <= true_ate <= ate_ub:
                     count_within_interval += 1
 
-        assert count_within_interval >= 8, f"True ATE falls within the interval bounds only {count_within_interval} times out of {num_iterations}"
+            assert count_within_interval >= 7, (
+                f"{est.__class__.__name__}: True ATE falls within the interval bounds "
+                f"only {count_within_interval} times out of {num_iterations}"
+            )
 
     # accuracy test, DML
     def test_accuracy_iv(self):
-        n = 10000
+        n = 1000
         discrete_outcome = True
         discrete_treatment = True
         true_ate = 0.3
-        W = np.random.uniform(-1, 1, size=(n, 1))
-        Z = np.random.uniform(-1, 1, size=(n, 1))
-        D = np.random.binomial(1, .5 + .1 * W[:, 0] + .1 * Z[:, 0], size=(n,))
-        Y = np.random.binomial(1, .5 + true_ate * D + .1 * W[:, 0], size=(n,))
+        num_iterations = 10
 
         ests = [
             OrthoIV(discrete_outcome=discrete_outcome, discrete_treatment=discrete_treatment),
@@ -75,14 +80,26 @@ class TestDiscreteOutcome(unittest.TestCase):
 
         for est in ests:
 
-            est.fit(Y, D, W=W, Z=Z)
-            ate = est.ate()
-            ate_lb, ate_ub = est.ate_interval()
+            count_within_interval = 0
 
-            est.summary()
+            for _ in range(num_iterations):
 
-            proportion_in_interval = ((ate_lb < true_ate) & (true_ate < ate_ub)).mean()
-            np.testing.assert_array_less(0.50, proportion_in_interval)
+                W = np.random.uniform(-1, 1, size=(n, 1))
+                Z = np.random.uniform(-1, 1, size=(n, 1))
+                D = np.random.binomial(1, .5 + .1 * W[:, 0] + .1 * Z[:, 0], size=(n,))
+                Y = np.random.binomial(1, .5 + true_ate * D + .1 * W[:, 0], size=(n,))
+
+                est.fit(Y, D, W=W, Z=Z)
+                ate_lb, ate_ub = est.ate_interval()
+                est.summary()
+
+                if ate_lb <= true_ate <= ate_ub:
+                    count_within_interval += 1
+
+            assert count_within_interval >= 7, (
+                f"{est.__class__.__name__}: True ATE falls within the interval bounds "
+                f"only {count_within_interval} times out of {num_iterations}"
+            )
 
     def test_string_outcome(self):
         n = 100
@@ -220,6 +237,6 @@ class TestDiscreteOutcome(unittest.TestCase):
                 if isinstance(est, LinearDRLearner):
                     est.model_regression = LinearRegression()
                 else:
-                    est.model_y = LinearRegression()
+                    est.model_y = LinearRegression() 
                 with pytest.warns(UserWarning):
                     est.fit(Y=Y, T=T, X=X)


### PR DESCRIPTION
- The original code is testing the accuracy of different estimators by checking if the true Average Treatment Effect (ATE) falls within the calculated confidence interval. However, the check is done only once, using a single-point estimate (ate), which may not be sufficient to validate the estimator's performance. So it failed when the proportion of a true ATE within the confidence interval is NOT greater than 0.5 (50%).

			
- The new logic: To check that 50% of the values are in the 90% confidence interval (which makes sense), but it's testing this with the ate, which returns a single value, so actually the threshold isn't important, it's a single point that is either in the interval or not.  Instead, what we should do is generate W, D, and Y several times and check that most of the time the ate is in the bounds (like, generate 10 sets of W, D, Y and check that at least 8 of those times the true ate was inside the interval.

- Also applied the logic for test_accuracy_iv (And reduced the sample size n=1000 to improve the test time)