### PR TITLE
Work around merge failures in subsequent CI attempts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,7 +338,11 @@ jobs:
         name: ${{ matrix.artifact }}
         pattern: "${{ matrix.artifact }}-*"
         delete-merged: true
-      
+      # if we are re-running a job in a subsequent attempt, some of the other artifacts may not exist in this attempt (e.g. notebooks, if only non-notebook tests failed)
+      # Unlike with plain upload-artifact, there's no way to ignore the situation where no files are found when using the v4 merge action
+      # (see https://github.com/actions/upload-artifact/issues/520), so just continue on error isntead
+      continue-on-error: true
+        
   build:
     name: Build package
     needs: [eval]

--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ For information on use cases and background material on causal inference and het
 
 If you'd like to contribute to this project, see the [Help Wanted](#help-wanted) section below.
 
-**February 12, 2024:** Release v0.15.0, see release notes [here](https://github.com/py-why/EconML/releases/tag/v0.15.0)
+**July 3, 2024:** Release v0.15.1, see release notes [here](https://github.com/py-why/EconML/releases/tag/v0.15.1)
 
 <details><summary>Previous releases</summary>
+
+**February 12, 2024:** Release v0.15.0, see release notes [here](https://github.com/py-why/EconML/releases/tag/v0.15.0)
 
 **November 11, 2023:** Release v0.15.0b1, see release notes [here](https://github.com/py-why/EconML/releases/tag/v0.15.0b1)
 

--- a/econml/_version.py
+++ b/econml/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) PyWhy contributors. All rights reserved.
 # Licensed under the MIT License.
 
-__version__ = '0.15.0'
+__version__ = '0.15.1'


### PR DESCRIPTION
The migration to the v4 version of the artifact API has somewhat broken rerunning tests for a PR in some scenarios because now artifacts are scoped to the attempt, but it's possible that we won't generate every type of artifact on every attempt (e.g. if all of our notebook tests passes in attempt 1, we won't try to run them again in attempt 2, see, e.g. https://github.com/py-why/EconML/actions/runs/8940985090/attempts/2 for a concrete example).

Unfortunately, the new merge artifact action's API doesn't provide a graceful way to handle this at the moment, so we can just set the step's `continue-on-error` property to true to ignore failures (ideally we wouldn't have to assume that this is the only reason the job can fail, but I don't see any obvious alternative).

Note that this isn't exactly a blocker, because our `Verify CI checks` job doesn't look for failures in the merge jobs anyway, but it's potentially confusing (IMO) that we can have red Xs on some jobs for the attempt and yet still merge the PR and so it would be better to have the merge jobs not fail in this case.  (There is some other semantic weirdness with the fact that artifacts are per-attempt, like the fact that we want the final coverage report to ideally include just the last (successful) run for each test configuration, but instead we'll get one separate coverage report per attempt that includes only the tests that were run in that attempt; again, there does not seem to be a clean workaround at the moment).