### PR TITLE
Fix documentation publishing workflow

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download docs artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docs
           path: html


### PR DESCRIPTION
In a previous change, we switched to v4 of the `upload-artifact` action but neglected to also use v4 of the `download-artifact` action, which breaks the publication workflow because the different versions are incompatible.