### PR TITLE
Disable Python 3.13 when building wheels for CI

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -69,9 +69,9 @@ jobs:
       - name: Ensure latest pip and setuptools
         run: python -m pip install --upgrade pip && pip install --upgrade setuptools
       - name: Build wheels
-        run: pip install cibuildwheel && python -m cibuildwheel --output-dir dist
+        run: pip install 'cibuildwheel < 3' && python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: cp3*
+          CIBW_BUILD: ${{ inputs.use_lkg && 'cp3{8,9,10,11,12}-*' || 'cp3*' }}
           CIBW_SKIP: "*musl* *win32 *i686"
       - name: Upload wheels as artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
A recent release of `cibuildwheel` has started including python 3.13, but `scipy` hasn't published any 3.13 builds yet (and building from source isn't working due to a fortran compiler issue), so building wheels on 3.13 fails.

That is fine for nightly builds, but bad for CI builds, where "last known good" should extend to versions of python as well as versions of our dependencies.  This fixes that issue by tying which versions of python are used by cibuildwheel to whether we're considering LKG status or not.