### PR TITLE
add compiled .c files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ double_ml/proto/*.jpg
 
 # sphinx autosummaries 
 doc/_autosummary/
+
+# compiled C files
+*.c


### PR DESCRIPTION
Previously, .c files were generated whenever we install the environment. 
![image](https://github.com/user-attachments/assets/07ea8b2a-9e95-4a92-8188-a7a41bc96d57)

I added them to .gitignore so we don't make a mistake merging them by accident if they should be ignored.