### PR TITLE
Fix coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,8 @@ jobs:
       if: success() || failure() && contains(fromJSON('["success", "failure"]'), steps.run_tests.outcome)
       with:
         name: coverage-${{ env.id_string }}
-        path: .coverage.${{ env.id_string }}    
+        path: .coverage.${{ env.id_string }}  
+        hidden-files: true
     - name: Make test XML filename unique
       run: mv junit/test-results.xml ${{ env.id_string }}-test-results.xml
       # Run whether or not the tests passed, but only if they ran at all
@@ -278,6 +279,7 @@ jobs:
       with:
         name: coverage-${{ env.id_string }}
         path: .coverage.${{ env.id_string }}
+        hidden-files: true
     - name: Make test XML filename unique
       run: mv junit/test-results.xml ${{ env.id_string }}-test-results.xml
       # Run whether or not the tests passed, but only if they ran at all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,8 +177,9 @@ jobs:
       if: success() || failure() && contains(fromJSON('["success", "failure"]'), steps.run_tests.outcome)
       with:
         name: coverage-${{ env.id_string }}
-        path: .coverage.${{ env.id_string }}  
-        hidden-files: true
+        path: .coverage.${{ env.id_string }}
+        # need to include hidden files since path starts with .
+        include-hidden-files: true
     - name: Make test XML filename unique
       run: mv junit/test-results.xml ${{ env.id_string }}-test-results.xml
       # Run whether or not the tests passed, but only if they ran at all
@@ -279,7 +280,8 @@ jobs:
       with:
         name: coverage-${{ env.id_string }}
         path: .coverage.${{ env.id_string }}
-        hidden-files: true
+        # need to include hidden files since path starts with .
+        include-hidden-files: true
     - name: Make test XML filename unique
       run: mv junit/test-results.xml ${{ env.id_string }}-test-results.xml
       # Run whether or not the tests passed, but only if they ran at all


### PR DESCRIPTION
A breaking change to the upload-artifact GitHub Action has broken uploading coverage files (not only for us, see https://github.com/actions/upload-artifact/issues/614) and has not been reverted. This change will fix that by enabling hidden files only for those uploads.