### PR TITLE
fix `dowhy_` not existance issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.6.2
+  rev: v0.7.3
   hooks:
     # Run the linter.
     - id: ruff

--- a/econml/dowhy.py
+++ b/econml/dowhy.py
@@ -233,11 +233,14 @@ class DoWhyWrapper:
             raise AttributeError(attr)
         elif attr == "dowhy_":
             if "dowhy_" not in dir(self):
-                raise RuntimeError("Please call DoWhyWrapper.fit first before any other operations")
+                raise AttributeError("Please call `DoWhyWrapper.fit` first before any other operations.")
             else:
                 return self.dowhy_
         elif attr in ['_cate_estimator', 'identified_estimand_', 'estimate_']:
-            return getattr(self, attr)
+            if attr in dir(self):
+                return getattr(self, attr)
+            else:
+                raise AttributeError(f"call `DoWhyWrapper.fit` first before any other operations.")
         elif attr.startswith('dowhy__'):
             return getattr(self.dowhy_, attr[len('dowhy__'):])
         elif hasattr(self.estimate_._estimator_object, attr):

--- a/econml/dowhy.py
+++ b/econml/dowhy.py
@@ -240,7 +240,7 @@ class DoWhyWrapper:
             if attr in dir(self):
                 return getattr(self, attr)
             else:
-                raise AttributeError(f"call `DoWhyWrapper.fit` first before any other operations.")
+                raise AttributeError("call `DoWhyWrapper.fit` first before any other operations.")
         elif attr.startswith('dowhy__'):
             return getattr(self.dowhy_, attr[len('dowhy__'):])
         elif hasattr(self.estimate_._estimator_object, attr):

--- a/econml/dowhy.py
+++ b/econml/dowhy.py
@@ -231,9 +231,13 @@ class DoWhyWrapper:
         # don't proxy special methods
         if attr.startswith('__'):
             raise AttributeError(attr)
-        elif attr in ['_cate_estimator', 'dowhy_',
-                      'identified_estimand_', 'estimate_']:
-            return super().__getattr__(attr)
+        elif attr == "dowhy_":
+            if "dowhy_" not in dir(self):
+                raise RuntimeError("Please call DoWhyWrapper.fit first before any other operations")
+            else:
+                return self.dowhy_
+        elif attr in ['_cate_estimator', 'identified_estimand_', 'estimate_']:
+            return getattr(self, attr)
         elif attr.startswith('dowhy__'):
             return getattr(self.dowhy_, attr[len('dowhy__'):])
         elif hasattr(self.estimate_._estimator_object, attr):

--- a/econml/tests/test_dowhy.py
+++ b/econml/tests/test_dowhy.py
@@ -95,3 +95,12 @@ class TestDowhy(unittest.TestCase):
         np.testing.assert_array_equal(est._effect_modifiers, X_name)
         np.testing.assert_array_equal(est._treatment, [T_name])
         np.testing.assert_array_equal(est._outcome, [Y_name])
+
+    def test_dowhy_without_fit(self):
+        with self.assertRaises(AttributeError) as context:
+            LinearDRLearner().dowhy.refute_estimate(method_name="random_common_cause", num_simulations=3)
+        self.assertTrue("Please call `DoWhyWrapper.fit` first before any other operations." in str(context.exception))
+
+        with self.assertRaises(AttributeError) as context:
+            LinearDRLearner().dowhy._estimator_object
+        self.assertTrue("call `DoWhyWrapper.fit` first before any other operations." in str(context.exception))


### PR DESCRIPTION
1. `object` has no `__getattr__` attribute so calling `super().__getattr__` is wrong, should change it to `getattr(self, name)`.
2. `dowhy_` is not exist until `fit` is called, just have a more intuitive error message when someone calls methods without `fitting`.