### PR TITLE
Fix numpy iterable import in _causal_analysis.py for numpy>2.0

### DIFF
--- a/econml/solutions/causal_analysis/_causal_analysis.py
+++ b/econml/solutions/causal_analysis/_causal_analysis.py
@@ -9,7 +9,7 @@ from collections import OrderedDict, namedtuple
 import joblib
 import lightgbm as lgb
 import numpy as np
-from numpy.lib.function_base import iterable
+from numpy import iterable
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.compose import ColumnTransformer


### PR DESCRIPTION
With new numpy 2.0 update the numpy.lib.function_base namespace has become private.
If you try to import it you get the error:

```
    raise AttributeError(
AttributeError: numpy.lib.function_base is now private. If you are using a public function, it should be available in the main numpy namespace, otherwise check the NumPy 2.0 migration guide.
```

In econml this throws the exception:

```
/usr/share/miniconda/envs/test/lib/python3.9/site-packages/responsibleai/managers/causal_manager.py:10: in <module>
    from econml.solutions.causal_analysis import CausalAnalysis
/usr/share/miniconda/envs/test/lib/python3.9/site-packages/econml/solutions/causal_analysis/__init__.py:4: in <module>
    from ._causal_analysis import CausalAnalysis
/usr/share/miniconda/envs/test/lib/python3.9/site-packages/econml/solutions/causal_analysis/_causal_analysis.py:13: in <module>
    from numpy.lib.function_base import iterable
E   ModuleNotFoundError: No module named 'numpy.lib.function_base'
```

The fix is to import the function from numpy directly, which is also backwards compatible.