### PR TITLE
Fix CI build by limiting builds to not py 13

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Build wheels
         run: pip install 'cibuildwheel < 3' && python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: ${{ inputs.use_lkg && 'cp3{8,9,10,11,12}-*' || 'cp3*' }}
+          CIBW_BUILD: ${{ inputs.use_lkg && 'cp3{8,9,10,11,12}-*' || 'cp3{8,9,10,11,12}*' }}
           CIBW_SKIP: "*musl* *win32 *i686"
       - name: Upload wheels as artifact
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux"


### PR DESCRIPTION
Example of passing build here:
https://github.com/BlueDrink9/EconML/actions/runs/14893898354