### PR TITLE
License problem with 16 when installing on Databricks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [{ name = "PyWhy contributors" }]
 description = "This package contains several methods for calculating Conditional Average Treatment Effects"
 readme = "README.md"
 keywords = ["treatment-effect"]
-license = "MIT"
+license = { text = "MIT" }
 dynamic = ["version"]
 
 classifiers = [


### PR DESCRIPTION
PEP 621 violation causes issues with installing databricks.

Signed-off-by: Dustin Smith dustin.william.smith@gmail.com

Fixes py-why/EconML#1010