### PR TITLE
Fix drtester dataframe

### DIFF
--- a/econml/tests/test_drtester.py
+++ b/econml/tests/test_drtester.py
@@ -286,3 +286,34 @@ class TestDRTester(unittest.TestCase):
 
         autoc_res = my_dr_tester.evaluate_uplift(Xval, Xtrain, metric='toc')
         self.assertLess(autoc_res.pvals[0], 0.05)
+
+    def test_dataframe_input(self):
+        Xtrain, Dtrain, Ytrain, Xval, Dval, Yval = self._get_data(num_treatments=1)
+
+        reg_t = RandomForestClassifier(random_state=0)
+        reg_y = GradientBoostingRegressor(random_state=0)
+
+        cate = DML(
+            model_y=reg_y,
+            model_t=reg_t,
+            model_final=reg_y,
+            discrete_treatment=True
+        ).fit(Y=Ytrain, T=Dtrain, X=Xtrain)
+
+        # Fit with numpy arrays as baseline
+        dr_numpy = DRTester(
+            model_regression=reg_y,
+            model_propensity=reg_t,
+            cate=cate
+        ).fit_nuisance(Xval, Dval, Yval, Xtrain, Dtrain, Ytrain)
+
+        # Fit with DataFrames/Series
+        dr_pandas = DRTester(
+            model_regression=reg_y,
+            model_propensity=reg_t,
+            cate=cate
+        ).fit_nuisance(
+            pd.DataFrame(Xval), pd.Series(Dval), pd.Series(Yval),
+            pd.DataFrame(Xtrain), pd.Series(Dtrain), pd.Series(Ytrain)
+        )
+        np.testing.assert_array_equal(dr_pandas.dr_val_, dr_numpy.dr_val_)

--- a/econml/validate/drtester.py
+++ b/econml/validate/drtester.py
@@ -8,7 +8,7 @@ from sklearn.model_selection import cross_val_predict, StratifiedKFold, KFold
 from statsmodels.api import OLS
 from statsmodels.tools import add_constant
 
-from econml.utilities import deprecated
+from econml.utilities import check_input_arrays, deprecated
 
 from .results import CalibrationEvaluationResults, BLPEvaluationResults, UpliftEvaluationResults, EvaluationResults
 from .utils import calculate_dr_outcomes, calc_uplift
@@ -221,15 +221,8 @@ class DRTester:
         If training data is provided, also adds attributes for the doubly robust outcomes for the training
         set (dr_train) and the training treatments (Dtrain)
         """
-        Xval = np.asarray(Xval)
-        Dval = np.asarray(Dval)
-        yval = np.asarray(yval)
-        if Xtrain is not None:
-            Xtrain = np.asarray(Xtrain)
-        if Dtrain is not None:
-            Dtrain = np.asarray(Dtrain)
-        if ytrain is not None:
-            ytrain = np.asarray(ytrain)
+        Xval, Dval, yval = check_input_arrays(Xval, Dval, yval)
+        Xtrain, Dtrain, ytrain = check_input_arrays(Xtrain, Dtrain, ytrain)
 
         self.Dval = Dval
 

--- a/econml/validate/drtester.py
+++ b/econml/validate/drtester.py
@@ -221,6 +221,16 @@ class DRTester:
         If training data is provided, also adds attributes for the doubly robust outcomes for the training
         set (dr_train) and the training treatments (Dtrain)
         """
+        Xval = np.asarray(Xval)
+        Dval = np.asarray(Dval)
+        yval = np.asarray(yval)
+        if Xtrain is not None:
+            Xtrain = np.asarray(Xtrain)
+        if Dtrain is not None:
+            Dtrain = np.asarray(Dtrain)
+        if ytrain is not None:
+            ytrain = np.asarray(ytrain)
+
         self.Dval = Dval
 
         # Unique treatments (ordered, includes control)


### PR DESCRIPTION
DRTester.fit_nuisance fails when passed pandas DataFrames because fit_nuisance_cv uses numpy-style integer array indexing (X[train]) with the index arrays from StratifiedKFold.split(). Pandas interprets these as column selection, causing a KeyError.

This adds input conversion at the top of fit_nuisance using check_input_arrays, consistent with how other estimators in the package handle this (e.g., _OrthoLearner.fit).

Fixes #852