### PR TITLE
Fix off-by-one in score_nuisances for discrete treatments (closes #1006)

### DIFF
--- a/econml/dml/_rlearner.py
+++ b/econml/dml/_rlearner.py
@@ -34,7 +34,7 @@ from sklearn.metrics import (
 )
 from typing import Callable, Union
 from ..sklearn_extensions.model_selection import ModelSelector
-from ..utilities import (filter_none_kwargs)
+from ..utilities import (filter_none_kwargs, reshape)
 from .._ortho_learner import _OrthoLearner
 
 class _ModelNuisance(ModelSelector):
@@ -628,9 +628,13 @@ class _RLearner(_OrthoLearner):
             T_Key : []
         }
 
-        # For discrete treatments, these will have to be one hot encoded
         Y_2_score = pd.get_dummies(Y) if self.discrete_outcome and (len(Y.shape) == 1 or Y.shape[1] == 1) else Y
-        T_2_score = pd.get_dummies(T) if self.discrete_treatment and (len(T.shape) == 1 or T.shape[1] == 1) else T
+        if self.transformer:
+            if self.discrete_treatment:
+                T = reshape(T, (-1, 1))
+            T_2_score = self.transformer.transform(T)
+        else:
+            T_2_score = T
 
         for m in self._models_nuisance[0]:
             Y_score, T_score = m.score(Y_2_score, T_2_score, X=X, W=W, Z=Z, sample_weight=sample_weight,

--- a/econml/tests/test_dml.py
+++ b/econml/tests/test_dml.py
@@ -789,19 +789,19 @@ class TestDML(unittest.TestCase):
                                   t_scoring='mean_squared_error',
                                   y_scoring='mean_squared_error')
         np.testing.assert_allclose(sn1['Y_mean_squared_error'], [2.8,2.8], rtol=0, atol=.1)
-        np.testing.assert_allclose(sn1['T_mean_squared_error'], [1.5,1.5], rtol=0, atol=.1)
+        np.testing.assert_allclose(sn1['T_mean_squared_error'], [0.48,0.48], rtol=0, atol=.1)
 
         sn2 = est.score_nuisances(Y=y, T=T, X=X, W=W,
                                   t_scoring='mean_absolute_error',
                                   y_scoring='mean_absolute_error')
         np.testing.assert_allclose(sn2['Y_mean_absolute_error'], [1.3,1.3], rtol=0, atol=.1)
-        np.testing.assert_allclose(sn2['T_mean_absolute_error'], [1.0,1.0], rtol=0, atol=.1)
+        np.testing.assert_allclose(sn2['T_mean_absolute_error'], [0.48,0.48], rtol=0, atol=.1)
 
         sn3 = est.score_nuisances(Y=y, T=T, X=X, W=W,
                                   t_scoring='r2',
                                   y_scoring='r2')
         np.testing.assert_allclose(sn3['Y_r2'], [0.27,0.27], rtol=0, atol=.005)
-        np.testing.assert_allclose(sn3['T_r2'], [-5.1,-5.1], rtol=0, atol=0.25)
+        np.testing.assert_allclose(sn3['T_r2'], [-0.93,-0.93], rtol=0, atol=0.05)
 
         sn4 = est.score_nuisances(Y=y, T=T, X=X, W=W,
                                   t_scoring=pearsonr,
@@ -818,6 +818,36 @@ class TestDML(unittest.TestCase):
 
         sn6 = est.score_nuisances(Y=y, T=T, X=X, W=W, t_scoring='log_loss')
         np.testing.assert_allclose(sn6['T_log_loss'], [17.4,17.4], rtol=0, atol=0.1)
+
+    def test_score_nuisances_discrete_treatment_label_alignment(self):
+        # Regression test for #1006: score_nuisances built T_2_score with
+        # pd.get_dummies(T) (all k columns), but the classifier was trained
+        # on labels from OneHotEncoder(drop='first'), so inverse_onehot at
+        # score time decoded labels off-by-one and the classifier score
+        # collapsed below chance. Use a ternary T with signal in X so the
+        # post-fix accuracy is well above the 1/3 chance floor.
+        rng = np.random.default_rng(0)
+        n = 3000
+        X = rng.normal(size=(n, 3))
+        logits = np.column_stack([np.zeros(n), 1.5 * X[:, 0], 1.5 * X[:, 1]])
+        probs = np.exp(logits) / np.exp(logits).sum(axis=1, keepdims=True)
+        T = np.array([rng.choice(3, p=p) for p in probs])
+        y = T.astype(float) + X[:, 0] + rng.normal(size=n)
+
+        est = LinearDML(model_y=LinearRegression(),
+                        model_t=LogisticRegression(max_iter=500),
+                        discrete_treatment=True, cv=3, random_state=0)
+        est.fit(y, T, X=X, cache_values=True)
+
+        scores = est.score_nuisances(y, T, X=X)
+        t_key = next(k for k in scores if k.startswith("T_"))
+        t_scores = scores[t_key]
+        # Pre-fix this collapses near 0.13 (worse than 1/3 chance) because
+        # the classifier predicts labels in {0,1,2} but inverse_onehot decoded
+        # the get_dummies(T) one-hot to {1,2,3}. Post-fix the LR recovers
+        # signal well above chance.
+        for s in t_scores:
+            assert s > 0.5, f"score_nuisances T score {s} suggests label misalignment (#1006)"
 
     def test_aaforest_pandas(self):
         """Test that we can use CausalForest with pandas inputs."""

--- a/econml/tests/test_treatment_featurization.py
+++ b/econml/tests/test_treatment_featurization.py
@@ -599,3 +599,30 @@ class TestTreatmentFeaturization(unittest.TestCase):
         from .test_dml import TestDML
         treatment_featurizations = [FunctionTransformer()]
         TestDML()._test_cate_api(treatment_featurizations)
+
+    def test_score_nuisances_applies_treatment_featurizer(self):
+        # Regression test for #1006 / #1029: when a treatment_featurizer is
+        # used, the nuisance model_t is trained on featurized T, so
+        # score_nuisances must also featurize T at score time. Previously
+        # it passed raw T, producing a shape mismatch against the trained
+        # multi-output regressor.
+        rng = np.random.default_rng(0)
+        n = 1000
+        X = rng.normal(size=(n, 3))
+        T = rng.normal(size=n)
+        Y = 2 * T + T**2 + X[:, 0] + rng.normal(size=n)
+
+        est = LinearDML(
+            model_y=LinearRegression(),
+            model_t=LinearRegression(),
+            treatment_featurizer=polynomial_treatment_featurizer,
+            cv=2,
+            random_state=0,
+        )
+        est.fit(Y, T, X=X, cache_values=True)
+
+        scores = est.score_nuisances(Y, T, X=X)
+        t_key = next(k for k in scores if k.startswith("T_"))
+        for s in scores[t_key]:
+            assert np.isfinite(s), \
+                f"score_nuisances T score {s} is not finite (#1006/#1029)"


### PR DESCRIPTION
https://github.com/py-why/EconML/issues/1006#issuecomment-4392015743

## Evidence

Reproducer: ternary T (3 classes) with signal in X, `LinearDML` +
`LogisticRegression` nuisance, `cv=3`. Mean `score_nuisances` across folds:

| Metric                | Pre-fix | Post-fix | Notes                              |
| --------------------- | ------- | -------- | ---------------------------------- |
| T default score (acc) | **0.13**| **0.63** | 1/3 chance floor for 3-class       |
| Y default score (R²)  |  0.44   |  0.44    | unchanged — bug isolates to T path |

Pre-fix the classifier scores **below random** because `pd.get_dummies(T)`
keeps all *k* columns and `inverse_onehot` decodes labels as `{1..k}` while
the classifier was trained on `{0..k-1}`. Post-fix the same classifier
recovers genuine signal.

The existing `test_forest_dml_score_fns` already exercised this path and
its expected values silently encoded the bug; they're updated here to the
correct post-fix values:

| Assertion (`T_*`)   | Was (pre-fix)  | Now (post-fix) |
| ------------------- | -------------- | -------------- |
| `mean_squared_error`|  1.5           |  0.48          |
| `mean_absolute_error`|  1.0          |  0.48          |
| `r2`                | −5.1           | −0.93          |

`roc_auc`, `log_loss`, and `pearsonr` are approximately invariant under
the off-by-one label shift, which is why the existing test didn't fail
loud — the three metrics where label distance matters were the ones that
silently absorbed the gap.