### PR TITLE
Add liveness probe for OpenML in notebook tests to handle API downtime

### DIFF
--- a/econml/tests/test_notebooks.py
+++ b/econml/tests/test_notebooks.py
@@ -41,35 +41,31 @@ def _openml_is_down():
     from sklearn.datasets import fetch_openml
 
     try:
-        fetch_openml(data_id=61, as_frame=False, parser="liac-arff")  # iris
+        fetch_openml(data_id=61, as_frame=False)  # iris
         return False
     except urllib.error.HTTPError as e:
-        # 5xx = OpenML's servers are unhappy; treat as "down".
-        # 4xx would indicate a real bug (bad request, removed dataset, ...).
-        return e.code >= 500
+        # 5xx = server-side problem, 408 = request timeout, 429 = rate-limited:
+        # all are transient "OpenML can't serve this right now" conditions.
+        # Other 4xx (e.g. 404) indicate a real bug we shouldn't paper over.
+        return e.code >= 500 or e.code in (408, 429)
     except (urllib.error.URLError, TimeoutError):
         return True
 
 
-def _notebook_params():
-    openml_down = None  # probe lazily, only if needed
-    for nb in _notebooks:
-        if "Ames Housing" in nb:
-            if openml_down is None:
-                openml_down = _openml_is_down()
-            marks = [pytest.mark.xfail(openml_down,
-                                       reason="OpenML appears to be unavailable",
-                                       strict=False)] if openml_down else []
-            yield pytest.param(nb, marks=marks)
-        else:
-            yield nb
-
-
-@pytest.mark.parametrize("file", list(_notebook_params()))
+@pytest.mark.parametrize("file", _notebooks)
 @pytest.mark.notebook
 def test_notebook(file):
     import nbformat
     import nbconvert
+
+    # The Ames Housing notebook is the only one that depends on OpenML. When
+    # OpenML's API is down the notebook is doomed to fail, so probe first and
+    # xfail before paying the cost of running every cell. There's a small
+    # window where OpenML could recover between this probe and the test
+    # actually running, but the time savings from skipping the full notebook
+    # execution are worth it.
+    if "Ames Housing" in file and _openml_is_down():
+        pytest.xfail("OpenML appears to be unavailable")
 
     nb = nbformat.read(os.path.join(_nbdir, file), as_version=4)
 

--- a/econml/tests/test_notebooks.py
+++ b/econml/tests/test_notebooks.py
@@ -48,7 +48,11 @@ def _openml_is_down():
         # all are transient "OpenML can't serve this right now" conditions.
         # Other 4xx (e.g. 404) indicate a real bug we shouldn't paper over.
         return e.code >= 500 or e.code in (408, 429)
-    except (urllib.error.URLError, TimeoutError):
+    except OSError:
+        # Any other network/transport-level failure: URLError, socket.timeout /
+        # TimeoutError, http.client.RemoteDisconnected, ConnectionResetError,
+        # ConnectionRefusedError, BrokenPipeError, ... All of these inherit
+        # from OSError and all mean "we couldn't talk to OpenML right now."
         return True
 
 

--- a/econml/tests/test_notebooks.py
+++ b/econml/tests/test_notebooks.py
@@ -23,7 +23,49 @@ _notebooks = [
 _notebooks = [nb for nb in _notebooks if "Lalonde" not in nb]
 
 
-@pytest.mark.parametrize("file", _notebooks)
+def _openml_is_down():
+    """Quick liveness probe for ``sklearn.datasets.fetch_openml``.
+
+    The Ames Housing notebook (and only that one) calls ``fetch_openml``,
+    which depends on OpenML's API endpoints. Those endpoints go down
+    periodically, which is not something this repo can fix; when they're down
+    we don't want the notebook test to register as a real failure.
+
+    We drive the probe through ``fetch_openml`` itself rather than poking a
+    hardcoded URL, so this tracks whatever endpoints the installed sklearn
+    actually uses (e.g. if sklearn migrates to an OpenML v2 API in the
+    future). We point at a small dataset (``iris``) so the metadata round-trip
+    is cheap; on success we ignore the returned bunch entirely.
+    """
+    import urllib.error
+    from sklearn.datasets import fetch_openml
+
+    try:
+        fetch_openml(data_id=61, as_frame=False, parser="liac-arff")  # iris
+        return False
+    except urllib.error.HTTPError as e:
+        # 5xx = OpenML's servers are unhappy; treat as "down".
+        # 4xx would indicate a real bug (bad request, removed dataset, ...).
+        return e.code >= 500
+    except (urllib.error.URLError, TimeoutError):
+        return True
+
+
+def _notebook_params():
+    openml_down = None  # probe lazily, only if needed
+    for nb in _notebooks:
+        if "Ames Housing" in nb:
+            if openml_down is None:
+                openml_down = _openml_is_down()
+            marks = [pytest.mark.xfail(openml_down,
+                                       reason="OpenML appears to be unavailable",
+                                       strict=False)] if openml_down else []
+            yield pytest.param(nb, marks=marks)
+        else:
+            yield nb
+
+
+@pytest.mark.parametrize("file", list(_notebook_params()))
 @pytest.mark.notebook
 def test_notebook(file):
     import nbformat


### PR DESCRIPTION
One notebook test (Ames Housing) has been failing since 5/27 because we can't fetch the OpenML dataset it depends on. This change will alter the status of that one notebook test to XFAIL (expected failure) when OpenML is down, but leave it unmodified to run as usual when OpenML dataset loading works.