### PR TITLE
Fix flaky tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,14 @@ jobs:
       env:
         PYTEST_ADDOPTS: ${{ matrix.opts }}
         COVERAGE_PROCESS_START: 'pyproject.toml'
+        # Force matplotlib's non-interactive backend to avoid the intermittent
+        # `_tkinter.TclError: Can't find a usable init.tcl` failure that the
+        # hosted Windows runners hit when matplotlib auto-selects TkAgg.
+        # See https://github.com/actions/setup-python/issues/1102. Setting this
+        # unconditionally (not just on Windows) keeps behavior consistent
+        # across the matrix and matches what other projects affected by the
+        # same flake have done.
+        MPLBACKEND: Agg
     - name: Make coverage filename unique
       run: mv .coverage .coverage.${{ env.id_string }}
       # Run whether or not the tests passed, but only if they ran at all

--- a/README.md
+++ b/README.md
@@ -649,6 +649,8 @@ This project uses [pytest](https://docs.pytest.org/) to run tests for continuous
 
 Because running all tests can be very time-consuming, we recommend running only the relevant subset of tests when developing locally.  The easiest way to do this is to rely on `pytest`'s compatibility with `unittest`, so you can just run `python -m unittest econml.tests.test_module` to run all tests in a given module, or `python -m unittest econml.tests.test_module.TestClass` to run all tests in a given class.  You can also run `python -m unittest econml.tests.test_module.TestClass.test_method` to run a single test method.
 
+Some of our tests exercise plotting code that imports `matplotlib`.  Our CI sets `MPLBACKEND=Agg` so that matplotlib selects a non-interactive backend; if you run these tests locally (particularly on Windows, where matplotlib's default Tk backend can fail to initialize), you may want to do the same, e.g. `$env:MPLBACKEND = "Agg"` in PowerShell or `export MPLBACKEND=Agg` in bash before invoking `pytest`/`unittest`.
+
 ## Generating the documentation
 
 This project's documentation is generated via [Sphinx](https://www.sphinx-doc.org/en/main/index.html).  Note that we use [graphviz](https://graphviz.org/)'s 

--- a/econml/tests/test_cate_interpreter.py
+++ b/econml/tests/test_cate_interpreter.py
@@ -13,8 +13,6 @@ try:
     from graphviz import Graph
     g = Graph()
     g.render()
-    import matplotlib
-    matplotlib.use('Agg')
 except Exception:
     graphviz_works = False
 

--- a/econml/tests/test_dmliv.py
+++ b/econml/tests/test_dmliv.py
@@ -213,7 +213,11 @@ class TestDMLIV(unittest.TestCase):
         groups = [i // 4 for i in range(n)]
         y = groups
         n_copies = {i: 4 for i in range(125)}
-        ct_lims = (62, 63)  # floor(n_groups / 2), ceil(n_groups / 2)
+        n_groups = len(n_copies)
+
+        # Because we're using a StratifiedGroupKFold, we aren't guaranteed to get as close to n_groups/cv
+        # copies of each group as possible; in practice we can see +/-1 extra compared to the ceiling/floor
+        ct_lims = (n_groups // 2 - 1, n_groups - n_groups // 2 + 1)
 
         est_list = [
             OrthoIV(

--- a/econml/tests/test_dowhy.py
+++ b/econml/tests/test_dowhy.py
@@ -61,11 +61,6 @@ class TestDowhy(unittest.TestCase):
                 else:
                     est_dowhy = est.dowhy.fit(Y, T, X=X, W=W)
                 # test causal graph
-                # need to set matplotlib backend before viewing model
-
-                import matplotlib
-                matplotlib.use('Agg')
-
                 est_dowhy.view_model(layout=None)
                 # test refutation estimate
                 est_dowhy.refute_estimate(method_name="random_common_cause", num_simulations=3)

--- a/econml/tests/test_driv.py
+++ b/econml/tests/test_driv.py
@@ -354,11 +354,15 @@ class TestDRIV(unittest.TestCase):
         groups = [i // 4 for i in range(n)]
         y = groups
         n_copies = {i: 4 for i in range(125)}
+        n_groups = len(n_copies)
 
         def ceil(a, b):  # ceiling analog of //
             return -(a // -b)
-        ct_lims_2 = (125 // 2, ceil(125, 2))
-        ct_lims_3 = (125 - ceil(125, 3), 125 - 125 // 3)
+
+        # Because we're using a StratifiedGroupKFold, we aren't guaranteed to get as close to n_groups/cv
+        # copies of each group as possible; in practice we can see +/-1 extra compared to the ceiling/floor
+        ct_lims_2 = (n_groups // 2 - 1, ceil(n_groups, 2) + 1)
+        ct_lims_3 = (n_groups - ceil(n_groups, 3) - 1, n_groups - n_groups // 3 + 1)
 
         est_list = [
             DRIV(

--- a/econml/tests/test_shap.py
+++ b/econml/tests/test_shap.py
@@ -125,8 +125,6 @@ class TestShap(unittest.TestCase):
 
     def test_identical_output(self):
         # import here since otherwise test collection would fail if matplotlib is not installed
-        import matplotlib
-        matplotlib.use('Agg')
         from shap.plots import scatter, heatmap, bar, beeswarm, waterfall
 
         # Treatment effect function


### PR DESCRIPTION
This PR should fix two semi-frequent kinds of flaky test failure: our DRIV/DMLIV grouping tests and tests that fail due to a GitHub Actions infrastructure issue where Windows images sometimes have nonfunctional tk environments