### PR TITLE
docs: document CausalForestDML reproducibility requirements (closes #971, #962)

### DIFF
--- a/econml/dml/causal_forest.py
+++ b/econml/dml/causal_forest.py
@@ -535,6 +535,17 @@ class CausalForestDML(_BaseDML):
         Options to pass to the remote function when using Ray.
         See https://docs.ray.io/en/latest/ray-core/api/doc/ray.remote.html
 
+    Notes
+    -----
+    **Reproducibility.** To obtain deterministic ``effect``,
+    ``effect_interval``, and related prediction outputs across runs, pass an
+    integer ``random_state`` at construction. Setting only
+    ``numpy.random.seed`` is not sufficient: the estimator uses its own
+    seeded random number generator, independent of the global numpy seed,
+    for cross-fitting splits and forest subsampling. Once fit with an
+    integer ``random_state``, predictions and confidence intervals are
+    stable across repeated calls and survive pickle round-trips.
+
     Examples
     --------
     A simple example with the default models and discrete treatment:


### PR DESCRIPTION
Closes #971 and #962.

## Motivation

Two open user issues report nondeterministic `CausalForestDML` outputs:

- [#962](https://github.com/py-why/EconML/issues/962): *"Despite setting fixed parameters, yet the CausalForestDML gets different results each time it is run? Tried setting a random seed, which also failed to effectively solve the problem."*
- [#971](https://github.com/py-why/EconML/issues/971): *"we get different prediction results every time we run the causal forest model... The model was pre-trained, saved and then loaded for predictions."*

I verified on `main` that `CausalForestDML` is fully reproducible — across repeated `effect`/`effect_interval` calls, pickle round-trips, and independent re-fits — when an integer `random_state` is passed at construction. I tested 8 configurations (`n_jobs` ∈ {None, 1, -1, 4}, `'auto'` first-stage, discrete treatment, varied `cv`); all show `max|Δ| = 0`.

The two reporters' likely root causes:

1. Setting only `numpy.random.seed(...)` globally instead of passing `random_state=<int>` to the estimator. The estimator owns its own seeded RNG path and does not consult the numpy global seed.
2. Constructing without `random_state` set (default `None`), in which case results are intentionally stochastic across fits.

Both are documentable as "missing reproducibility requirement," not code bugs.

## What changed

Adds a `Notes -> Reproducibility` section to the `CausalForestDML` docstring, immediately before `Examples`. Follows the numpy-doc section ordering convention. The note is anchored next to the existing `random_state` parameter documentation so users see both at once.

## Scope question

The same reproducibility requirement applies to the other DML estimators (`LinearDML`, `SparseLinearDML`, `NonParamDML`) that thread `random_state` through `_make_first_stage_selector`. I kept this PR scoped to `CausalForestDML` since both open issues specifically reference it. Happy to add the same note to the other DML docstrings in this PR (or a follow-up) if you'd prefer broader coverage.