### PR TITLE
fix: complete sklearn 1.9 support — drop self.alphas overwrite (closes #1032)

### DIFF
--- a/econml/sklearn_extensions/linear_model.py
+++ b/econml/sklearn_extensions/linear_model.py
@@ -437,7 +437,6 @@ class WeightedLassoCV(WeightedModelMixin, LassoCV):
                 cv=cv, verbose=verbose, n_jobs=n_jobs, positive=positive,
                 random_state=random_state, selection=selection)
             self.n_alphas = n_alphas
-            self.alphas = alphas
         else:
             super().__init__(
                 eps=eps, n_alphas=n_alphas, alphas=alphas,
@@ -561,7 +560,6 @@ class WeightedMultiTaskLassoCV(WeightedModelMixin, MultiTaskLassoCV):
                 cv=cv, verbose=verbose, n_jobs=n_jobs,
                 random_state=random_state, selection=selection)
             self.n_alphas = n_alphas
-            self.alphas = alphas
         else:
             super().__init__(
                 eps=eps, n_alphas=n_alphas, alphas=alphas,

--- a/econml/tests/test_linear_model.py
+++ b/econml/tests/test_linear_model.py
@@ -296,6 +296,35 @@ class TestLassoExtensions(unittest.TestCase):
         assert wrapper.max_iter == 100
         assert wrapper.tol == 0.01
 
+    def test_default_alphas_fits_on_strict_sklearn(self):
+        # Regression test for #1032. WeightedLassoCV.__init__ used to overwrite
+        # self.alphas = None after the version-dispatch correctly translated
+        # the default n_alphas=100 into alphas=100 on the super().__init__()
+        # call. sklearn 1.9's strict param validation rejected the resulting
+        # None and SparseLinearDML.fit / DebiasedLasso.fit raised
+        # InvalidParameterError. With default args, the dispatched alphas value
+        # must survive to fit time.
+        from packaging.version import parse
+        import sklearn
+        if parse(sklearn.__version__) < parse("1.7"):
+            self.skipTest("dispatch only active on sklearn 1.7+")
+
+        for cls in (WeightedLassoCV, WeightedMultiTaskLassoCV):
+            est = cls()
+            assert est.alphas is not None, \
+                f"{cls.__name__}.alphas was clobbered to None by __init__ (#1032)"
+            assert est.n_alphas == 100, \
+                f"{cls.__name__}.n_alphas should be preserved at 100 (#1032)"
+
+        rng = np.random.default_rng(0)
+        n = 300
+        X = rng.normal(size=(n, 3))
+        y_1d = rng.normal(size=n)
+        y_2d = rng.normal(size=(n, 2))
+        # neither call should raise sklearn.InvalidParameterError
+        WeightedLassoCV(cv=3).fit(X, y_1d)
+        WeightedMultiTaskLassoCV(cv=3).fit(X, y_2d)
+
     #################
     # DebiasedLasso #
     #################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     # in addition to dependencies)
     "numba > 0.53.1",
     "scipy > 1.4.0",
-    "scikit-learn >= 1.0, < 1.9",
+    "scikit-learn >= 1.0, < 1.10",
     "sparse",
     "joblib >= 0.13.0",
     "statsmodels >= 0.10",


### PR DESCRIPTION
Closes #1032.

## What's happening

[#1032](https://github.com/py-why/EconML/issues/1032) (filed by @jakevdp) reports that `import econml.orf` errors on scikit-learn 1.9 because `n_alphas` was removed from `LassoCV.__init__`.

The recent commit [`e546416`](https://github.com/py-why/EconML/commit/e54641686) added a `>= 1.7` version dispatch in `WeightedLassoCV.__init__` / `WeightedMultiTaskLassoCV.__init__` that translates `n_alphas=<int>` into `alphas=<int>` on the `super().__init__()` call. That fixes the import-time `TypeError` jakevdp reported.

But e546416 also added `self.alphas = alphas` at the end of the dispatch, which clobbers the value sklearn's `__init__` had correctly recorded back to the constructor's `alphas` kwarg (`None` by default):

```python
if parse(sklearn.__version__) >= parse("1.7"):
    super().__init__(
        eps=eps, alphas=alphas if alphas is not None else n_alphas,  # alphas=100 ✓
        ...)
    self.n_alphas = n_alphas
    self.alphas = alphas    # ← overwrites sklearn's alphas=100 back to None
```

On sklearn 1.7–1.8 the loose param-validation tolerated the resulting `self.alphas = None`. **On sklearn 1.9 the stricter `_param_validation` rejects it**, so `SparseLinearDML.fit` (via `_DebiasedLasso.fit` → `WeightedLassoCV`) and `DebiasedLasso.fit` raise:

```
sklearn.utils._param_validation.InvalidParameterError:
The 'alphas' parameter of WeightedLassoCV must be an int in the range [1, inf)
or an array-like. Got None instead.
```

## Fix

Drop the overwrite. `super().__init__(...)` already records `self.alphas` from the translated value. `self.n_alphas` is still set so callers can introspect the original wrapper kwarg.

Same edit applied to both `WeightedLassoCV.__init__` and `WeightedMultiTaskLassoCV.__init__`.

Also bumps `pyproject.toml` `scikit-learn >= 1.0, < 1.9` → `< 1.10` so users can actually install sklearn 1.9.

## Verification (locally, sklearn 1.9.0 + narwhals)

- `import econml.orf` ✓ (jakevdp's exact repro)
- Smoke fits all succeed on sklearn 1.9: `LinearDML`, `SparseLinearDML`, `CausalForestDML`, `DMLOrthoForest`, `LinearDRLearner`, `SparseLinearDRLearner`
- New `test_default_alphas_fits_on_strict_sklearn` regression test in `TestLassoExtensions`:
  - Asserts `WeightedLassoCV().alphas is not None` and `WeightedMultiTaskLassoCV().alphas is not None` (the dispatched value must survive)
  - Calls `.fit(...)` on each, verifying sklearn 1.9 strict validation accepts the result
  - Pre-fix on sklearn 1.9: fails with `AssertionError: WeightedLassoCV.alphas was clobbered to None by __init__ (#1032)`
  - Post-fix: passes
- Broader sweep: **48 passed, 0 failed** across `test_linear_model.py` + `test_dml.py` + `test_treatment_featurization.py` on sklearn 1.9.
