### PR TITLE
FIX: resolve sklearn 1.9 compatibility for WeightedLassoCV n_alphas deprecation (#1032 )

### DIFF
--- a/econml/sklearn_extensions/linear_model.py
+++ b/econml/sklearn_extensions/linear_model.py
@@ -430,14 +430,17 @@ class WeightedLassoCV(WeightedModelMixin, LassoCV):
         import sklearn
 
         if parse(sklearn.__version__) >= parse("1.7"):
+            # In sklearn 1.7+, 'alphas' accepts an int (number of alphas) or
+            # array-like (explicit alpha values). 'n_alphas' is deprecated in
+            # 1.7 and removed in 1.9.
+            alphas_param = alphas if alphas is not None else n_alphas
             super().__init__(
-                eps=eps, alphas=alphas if alphas is not None else n_alphas,
+                eps=eps, alphas=alphas_param,
                 fit_intercept=fit_intercept,
                 precompute=precompute, max_iter=max_iter, tol=tol, copy_X=copy_X,
                 cv=cv, verbose=verbose, n_jobs=n_jobs, positive=positive,
                 random_state=random_state, selection=selection)
             self.n_alphas = n_alphas
-            self.alphas = alphas
         else:
             super().__init__(
                 eps=eps, n_alphas=n_alphas, alphas=alphas,
@@ -445,6 +448,15 @@ class WeightedLassoCV(WeightedModelMixin, LassoCV):
                 precompute=precompute, max_iter=max_iter, tol=tol, copy_X=copy_X,
                 cv=cv, verbose=verbose, n_jobs=n_jobs, positive=positive,
                 random_state=random_state, selection=selection)
+
+    def get_params(self, deep=True):
+        """Get parameters, excluding deprecated n_alphas on sklearn >= 1.7."""
+        params = super().get_params(deep=deep)
+        from packaging.version import parse
+        import sklearn
+        if parse(sklearn.__version__) >= parse("1.7"):
+            params.pop('n_alphas', None)
+        return params
 
     def fit(self, X, y, sample_weight=None):
         """Fit model with coordinate descent.
@@ -554,14 +566,17 @@ class WeightedMultiTaskLassoCV(WeightedModelMixin, MultiTaskLassoCV):
         import sklearn
 
         if parse(sklearn.__version__) >= parse("1.7"):
+            # In sklearn 1.7+, 'alphas' accepts an int (number of alphas) or
+            # array-like (explicit alpha values). 'n_alphas' is deprecated in
+            # 1.7 and removed in 1.9.
+            alphas_param = alphas if alphas is not None else n_alphas
             super().__init__(
-                eps=eps, alphas=alphas if alphas is not None else n_alphas,
+                eps=eps, alphas=alphas_param,
                 fit_intercept=fit_intercept,
                 max_iter=max_iter, tol=tol, copy_X=copy_X,
                 cv=cv, verbose=verbose, n_jobs=n_jobs,
                 random_state=random_state, selection=selection)
             self.n_alphas = n_alphas
-            self.alphas = alphas
         else:
             super().__init__(
                 eps=eps, n_alphas=n_alphas, alphas=alphas,
@@ -569,6 +584,15 @@ class WeightedMultiTaskLassoCV(WeightedModelMixin, MultiTaskLassoCV):
                 max_iter=max_iter, tol=tol, copy_X=copy_X,
                 cv=cv, verbose=verbose, n_jobs=n_jobs,
                 random_state=random_state, selection=selection)
+
+    def get_params(self, deep=True):
+        """Get parameters, excluding deprecated n_alphas on sklearn >= 1.7."""
+        params = super().get_params(deep=deep)
+        from packaging.version import parse
+        import sklearn
+        if parse(sklearn.__version__) >= parse("1.7"):
+            params.pop('n_alphas', None)
+        return params
 
     def fit(self, X, y, sample_weight=None):
         """Fit model with coordinate descent.


### PR DESCRIPTION
## Summary

Fixes `InvalidParameterError` and `FutureWarning` when using EconML with scikit-learn >= 1.7 (where `n_alphas` is deprecated) and >= 1.9 (where it will be removed).

Closes #1032

## Problem

In sklearn 1.7+, `LassoCV` and `MultiTaskLassoCV` deprecated the `n_alphas` parameter in favor of passing an int directly to `alphas`. The existing version check in `WeightedLassoCV.__init__` correctly passes `alphas=n_alphas` to `super().__init__()`, but two issues remained:

1. **`self.alphas` was set to `None`** (the default `alphas` kwarg value) instead of the effective int value, causing `InvalidParameterError: The 'alphas' parameter must be an int or array-like. Got None instead` at fit time.

2. **`n_alphas` leaked into `get_params()` output.** When sklearn's `LinearModelCV.fit()` calls `self.get_params()` to build `path_params`, `n_alphas` was passed to `lasso_path()`, triggering `FutureWarning: 'n_alphas' was deprecated in 1.9 and will be removed in 1.11`.

## Fix

- Set `self.alphas` to the effective value (`alphas` if provided, else `n_alphas` as int) in the `>= 1.7` branch
- Override `get_params()` to exclude `n_alphas` from the returned dict on sklearn >= 1.7, preventing it from leaking into `lasso_path(**path_params)`
- Apply same fix to `WeightedMultiTaskLassoCV`

## Testing

Verified with sklearn 1.9.0:

| Test | Result |
|------|--------|
| Import `econml.orf` (triggers WeightedLassoCV init) | PASS |
| `WeightedLassoCV.fit()` with default n_alphas=100 | PASS |
| `WeightedLassoCV.fit()` with n_alphas=1 (edge) | PASS |
| `WeightedLassoCV.fit()` with n_alphas=1000 (large) | PASS |
| `WeightedLassoCV.fit()` with explicit alphas array | PASS |
| Both n_alphas and alphas provided (alphas takes precedence) | PASS |
| `WeightedMultiTaskLassoCV.fit()` | PASS |
| `WeightedLassoCVWrapper` single/multi-target | PASS |
| `WeightedLassoCVWrapper` with sample_weight | PASS |
| `DebiasedLasso` (uses WeightedLassoCV internally) | PASS |
| `LinearDML` end-to-end pipeline | PASS |
| `sklearn.clone()` compatibility | PASS |
| `set_params()` round-trip | PASS |
| Pickle serialization round-trip | PASS |
| Zero `FutureWarning` about n_alphas | PASS |
| Alpha grid size matches n_alphas (10, 50, 100, 200) | PASS |
| WeightedLassoCV == sklearn LassoCV when no weights (coef diff=0) | PASS |
| Sample weights correctly affect coefficients | PASS |
| DebiasedLasso CI coverage ~95% | PASS |

## Backward Compatibility

- `WeightedLassoCV(n_alphas=50)` still works on all sklearn versions
- `WeightedLassoCV(alphas=[0.1, 0.01])` still works
- `get_params()` / `set_params()` / `clone()` all work correctly
- No behavior change on sklearn < 1.7
