### PR TITLE
Refresh LKG and record the sklearn 1.9 forest behavior change

### DIFF
--- a/econml/dml/dml.py
+++ b/econml/dml/dml.py
@@ -1597,7 +1597,7 @@ class NonParamDML(_BaseDML):
         est.fit(y, T, X=X, W=None)
 
     >>> est.effect(X[:3])
-    array([0.35318, 1.28760, 0.83506])
+    array([0.22215931, 1.6484125 , 0.9278963 ])
     """
 
     def __init__(self, *,

--- a/lkg.txt
+++ b/lkg.txt
@@ -1,32 +1,34 @@
-Cython==3.2.4
+Cython==3.2.9
 Jinja2==3.1.6
 MarkupSafe==3.0.3
 PyYAML==6.0.3; (platform_system=='Darwin' and python_version<'3.14') or (platform_system=='Linux' and python_version<'3.14') or (platform_system=='Windows' and python_version<'3.13')
-argcomplete==3.6.3; platform_system=='Windows' and python_version=='3.12'
+argcomplete==3.7.0; platform_system=='Windows' and python_version=='3.12'
 attrs==26.1.0; (platform_system=='Darwin' and python_version<'3.14') or (platform_system=='Linux' and python_version<'3.14') or (platform_system=='Windows' and python_version<'3.13')
-causal-learn==0.1.4.5
-certifi==2026.2.25; (platform_system=='Darwin') or (platform_system=='Linux' and python_version<'3.14') or (platform_system=='Windows' and python_version<'3.13')
-cffi==2.0.0
-charset-normalizer==3.4.7; (platform_system=='Darwin' and python_version<'3.14') or (platform_system=='Linux' and python_version<'3.14') or (platform_system=='Windows' and python_version<'3.13')
+causal-learn==0.1.4.8
+certifi==2026.7.22; (platform_system=='Darwin') or (platform_system=='Linux' and python_version<'3.14') or (platform_system=='Windows' and python_version<'3.13')
+cffi==2.0.0; python_version<'3.10'
+cffi==2.1.1; python_version>='3.10'
+charset-normalizer==3.4.9; (platform_system=='Darwin' and python_version<'3.14') or (platform_system=='Linux' and python_version<'3.14') or (platform_system=='Windows' and python_version<'3.13')
 clarabel==0.11.1
 click==8.1.8; python_version<'3.10'
-click==8.3.2; (platform_system=='Darwin' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Linux' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Windows' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12'))
+click==8.4.2; (platform_system=='Darwin' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Linux' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Windows' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12'))
 cloudpickle==3.1.2
 colorama==0.4.6; platform_system=='Windows'
 contourpy==1.3.0; python_version<'3.10'
 contourpy==1.3.2; python_version=='3.10'
 contourpy==1.3.3; python_version>='3.11'
 cvxpy==1.7.5; python_version<'3.11'
-cvxpy==1.8.2; python_version>='3.11'
+cvxpy==1.9.2; python_version>='3.11'
 cycler==0.12.1
 dowhy==0.14
 filelock==3.19.1; python_version<'3.10'
-filelock==3.25.2; (platform_system=='Darwin' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Linux' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Windows' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12'))
+filelock==3.32.0; platform_system=='Windows' and python_version=='3.12'
+filelock==3.32.2; (platform_system=='Darwin' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Linux' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Windows' and (python_version=='3.10' or python_version=='3.11'))
 fonttools==4.60.2; python_version<'3.10'
-fonttools==4.62.1; python_version>='3.10'
+fonttools==4.63.0; python_version>='3.10'
 graphviz==0.21
-highspy==1.14.0; python_version>='3.11'
-idna==3.11; (platform_system=='Darwin' and python_version<'3.14') or (platform_system=='Linux' and python_version<'3.14') or (platform_system=='Windows' and python_version<'3.13')
+highspy==1.15.1; python_version>='3.11'
+idna==3.18; (platform_system=='Darwin' and python_version<'3.14') or (platform_system=='Linux' and python_version<'3.14') or (platform_system=='Windows' and python_version<'3.13')
 importlib_resources==6.5.2; python_version<'3.10'
 joblib==1.5.3
 jsonschema==4.25.1; python_version<'3.10'
@@ -34,68 +36,78 @@ jsonschema==4.26.0; (platform_system=='Darwin' and (python_version=='3.10' or py
 jsonschema-specifications==2025.9.1; (platform_system=='Darwin' and python_version<'3.14') or (platform_system=='Linux' and python_version<'3.14') or (platform_system=='Windows' and python_version<'3.13')
 kiwisolver==1.4.7; python_version<'3.10'
 kiwisolver==1.5.0; python_version>='3.10'
-lightgbm==4.6.0
+lightgbm==4.6.0; python_version<'3.10'
+lightgbm==4.7.0; python_version>='3.10'
 llvmlite==0.43.0; python_version<'3.10'
-llvmlite==0.47.0; python_version>='3.10'
+llvmlite==0.48.0; python_version>='3.10'
 matplotlib==3.9.4; python_version<'3.10'
-matplotlib==3.10.8; python_version>='3.10'
+matplotlib==3.10.9; python_version=='3.10'
+matplotlib==3.11.1; python_version>='3.11'
 momentchi2==0.1.8
 mpmath==1.3.0
-msgpack==1.1.2; (platform_system=='Darwin' and python_version<'3.14') or (platform_system=='Linux' and python_version<'3.14') or (platform_system=='Windows' and python_version<'3.13')
+msgpack==1.1.2; python_version<'3.10'
+msgpack==1.2.1; (platform_system=='Darwin' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Linux' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Windows' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12'))
+narwhals==2.24.0; python_version>='3.10'
 networkx==3.2.1; python_version<'3.10'
 networkx==3.4.2; python_version=='3.10'
 networkx==3.6.1; python_version>='3.11'
 numba==0.60.0; python_version<'3.10'
-numba==0.65.0; python_version>='3.10'
+numba==0.66.0; python_version>='3.10'
 numpy==2.0.2; python_version<'3.10'
 numpy==2.2.6; python_version=='3.10'
-numpy==2.4.4; python_version>='3.11'
-osqp==1.1.1
-packaging==26.0
+numpy==2.4.6; python_version>='3.11'
+osqp==1.1.3
+packaging==26.2; platform_system=='Windows' and python_version=='3.12'
+packaging==26.3; (platform_system=='Darwin') or (platform_system=='Linux') or (platform_system=='Windows' and python_version!='3.12')
 pandas==2.3.3; python_version<'3.11'
-pandas==3.0.2; python_version>='3.11'
+pandas==3.0.5; python_version>='3.11'
 patsy==1.0.2
 pillow==11.3.0; python_version<'3.10'
-pillow==12.2.0; python_version>='3.10'
-pipx==1.11.1; platform_system=='Windows' and python_version=='3.12'
-platformdirs==4.9.4; platform_system=='Windows' and python_version=='3.12'
+pillow==12.3.0; python_version>='3.10'
+pipx==1.16.3; platform_system=='Windows' and python_version=='3.12'
+platformdirs==4.11.0; platform_system=='Windows' and python_version=='3.12'
 protobuf==6.33.6; python_version<'3.10'
-protobuf==7.34.1; (platform_system=='Darwin' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Linux' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Windows' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12'))
+protobuf==7.35.1; (platform_system=='Darwin' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Linux' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Windows' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12'))
 pycparser==2.23; python_version<'3.10'
 pycparser==3.0; python_version>='3.10'
 pydot==4.0.1
 pyparsing==3.3.2
 python-dateutil==2.9.0.post0
-pytz==2026.1.post1; python_version<'3.11'
+pytz==2026.3.post1; python_version<'3.11'
+qdldl==0.1.9.post1; python_version>='3.11'
 ray==2.51.2; python_version<'3.10'
-ray==2.54.1; (platform_system=='Darwin' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Linux' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Windows' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12'))
+ray==2.56.1; (platform_system=='Darwin' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Linux' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Windows' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12'))
 referencing==0.36.2; python_version<'3.10'
 referencing==0.37.0; (platform_system=='Darwin' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Linux' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Windows' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12'))
 requests==2.32.5; python_version<'3.10'
-requests==2.33.1; (platform_system=='Darwin' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Linux' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Windows' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12'))
+requests==2.34.2; (platform_system=='Darwin' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Linux' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Windows' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12'))
 rpds-py==0.27.1; python_version<'3.10'
-rpds-py==0.30.0; (platform_system=='Darwin' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Linux' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Windows' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12'))
+rpds-py==0.30.0; python_version=='3.10'
+rpds-py==2026.6.3; (platform_system=='Darwin' and (python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Linux' and (python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Windows' and (python_version=='3.11' or python_version=='3.12'))
 scikit-learn==1.6.1; python_version<'3.10'
 scikit-learn==1.7.2; python_version=='3.10'
-scikit-learn==1.8.0; python_version>='3.11'
+scikit-learn==1.9.0; python_version>='3.11'
 scipy==1.13.1; python_version<'3.10'
 scipy==1.15.3; (platform_system=='Darwin' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12')) or (platform_system=='Linux' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12')) or (platform_system=='Windows' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12'))
-scipy==1.17.1; python_version>='3.13'
+scipy==1.18.0; python_version>='3.13'
 scs==3.2.11
-setuptools==82.0.1; python_version>='3.12'
+setuptools==83.0.0; python_version>='3.12'
 shap==0.49.1; python_version<'3.11'
-shap==0.51.0; python_version>='3.11'
+shap==0.51.0; python_version=='3.11'
+shap==0.52.0; python_version>='3.12'
 six==1.17.0
 slicer==0.0.8
 sparse==0.15.5; python_version<'3.10'
 sparse==0.17.0; python_version=='3.10'
-sparse==0.18.0; python_version>='3.11'
+sparse==0.19.1; python_version>='3.11'
+sparsediffpy==0.3.0; python_version>='3.11'
 statsmodels==0.14.6
 sympy==1.14.0
 threadpoolctl==3.6.0
-tqdm==4.67.3
-typing_extensions==4.15.0
-tzdata==2026.1; (platform_system=='Darwin' and python_version<'3.11') or (platform_system=='Linux' and python_version<'3.11') or (platform_system=='Windows')
-urllib3==2.6.3; (platform_system=='Darwin' and python_version<'3.14') or (platform_system=='Linux' and python_version<'3.14') or (platform_system=='Windows' and python_version<'3.13')
+tqdm==4.70.0
+typing_extensions==4.16.0; python_version<'3.13'
+tzdata==2026.3; (platform_system=='Darwin' and (python_version=='3.9' or python_version=='3.10')) or (platform_system=='Linux' and (python_version=='3.9' or python_version=='3.10')) or (platform_system=='Windows')
+urllib3==2.6.3; python_version<'3.10'
+urllib3==2.7.0; (platform_system=='Darwin' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Linux' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12' or python_version=='3.13')) or (platform_system=='Windows' and (python_version=='3.10' or python_version=='3.11' or python_version=='3.12'))
 userpath==1.9.2; platform_system=='Windows' and python_version=='3.12'
-zipp==3.23.0; python_version<'3.10'
+zipp==3.23.1; python_version<'3.10'


### PR DESCRIPTION
**Stacked on #1051** — base is `kebatt/doctest-drop-ellipses`, so review that first.

This updates `lkg.txt` to use scikit-learn 1.9 (from 1.8), and updates one doctest that needs to change as a result. The updated lkg.txt is the one generated from yesterday's nightly run.

The reason to address this now is that our nightlies are failing due to an sklearn change in 1.9 that changes some values in doctests; this change is actually an improvement: sklearn 1.9 changed `RandomForest`/`ExtraTrees` to use `sample_weight` when drawing the bootstrap sample, rather than forwarding the weights alongside a uniform mask. `NonParamDML` is maximally exposed, because its final-stage weights are literally `T_res**2` and therefore highly skewed, so we need to update one array in our doctests:

```
array([0.35318, 1.28760, 0.83506])  ->  array([0.22215931, 1.6484125 , 0.9278963 ])
```
